### PR TITLE
v0.1.6 - Minor Updates

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # MoviesThisDay Release Notes
 
+## v0.1.6 (2025-06-19)
+- Version bump and maintenance updates.
+- (Add new changes here)
+
 ## v0.1.5 (2025-06-19)
 - Added `/corrections` POST route for submitting movie corrections (configurable file, robust error handling, Docker/env support).
 - Added `/movie/{imdb_id}` route for JSON details of a movie by IMDb ID.
@@ -8,7 +12,7 @@
 - Improved documentation and docstrings across all scripts and endpoints.
 - Updated README to document new routes, correction workflow, and Docker usage.
 - General UI/UX improvements and code cleanup.
-- Date picker now auto-navigates when a date is picked from the calendar.
+- Date picker now auto-navigates when a date is picked from the calendar, but not when manually edited (manual edits require pressing Go or Enter).
 
 ## v0.1.4 (2025-06-18)
 - Added `/details/{imdb_id}` route and details page: full movie info, poster, ratings, and correction form.

--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 from fastapi.templating import Jinja2Templates
 import json
 
-VERSION = "0.1.5"
+VERSION = "0.1.6"
 
 POPULARITY_THRESHOLD = 10  # Only show movies with popularity above this value
 AGE_LIMIT = 100  # Only show movies released within this many years

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ httpx
 pytest
 requests
 colorama
+python-multipart

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ docker run -d \
   --health-retries=3 \
   -e TZ=America/Los_Angeles \
   -e CORRECTIONS_FILE=/data/corrections.jsonl \
-  -v $(PWD)/data:/data \
+  -v $(pwd)/data:/data \
   --log-opt max-size=10m \
   --log-opt max-file=3 \
   jasonacox/moviesthisday:latest

--- a/templates/index.html
+++ b/templates/index.html
@@ -438,7 +438,7 @@
                         <tbody>
                         {% for movie in movies %}
                             <tr>
-                                <td class="text-truncate" style="max-width:180px; word-break:break-word; white-space:nowrap;" title="{{ movie.title }}">
+                                <td class="text-truncate" style="max-width:180px; word-break:break-word; white-space:nowrap;">
                                     {% if movie.imdb_id %}
                                         <a href="/details/{{ movie.imdb_id }}" class="movie-title-link" data-imdb-id="{{ movie.imdb_id }}" style="color:#111; text-decoration:none; font-weight:inherit;">{{ movie.title }}</a>
                                     {% else %}


### PR DESCRIPTION
This pull request includes a version bump to `0.1.6` and several updates across documentation, scripts, and templates. Key changes include maintenance updates, improved behavior for the date picker, a fix for case sensitivity in the `run.sh` script, and a minor adjustment to the movie title tooltip in the UI.

### Version and Maintenance Updates:
* [`RELEASE.md`](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cR3-R6): Added release notes for version `0.1.6`, indicating a version bump and maintenance updates.
* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L33-R33): Updated the `VERSION` constant to `0.1.6`.

### Documentation and Behavior Improvements:
* [`RELEASE.md`](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cL11-R15): Clarified that the date picker auto-navigates when a date is picked from the calendar but requires manual confirmation when edited directly.

### Script Fix:
* [`run.sh`](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dL23-R23): Fixed the `pwd` command in the `docker run` command to be case-sensitive (`$(PWD)` → `$(pwd)`).

### UI Adjustment:
* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L441-R441): Removed the redundant `title` attribute from the movie title cell to avoid duplicate tooltips.