### PR TITLE
v0.1.14 - DB build fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # MoviesThisDay Release Notes
 
+## v0.1.14 (2026-02-01)
+- Fixed: Details page now handles `omdb_imdb_rating` as either float or string, preventing template errors when rating is a numeric type.
+- Database build fix: When duplicate movies are found (e.g., movie appears in both main CSV and trending CSV), the movie is now properly moved to the correct MM_DD date bucket if the release date changed.
+- Database build fix: `release_year` is now recalculated when a duplicate movie's release date is updated.
+- Database build fix: `apply_updates_jsonl` now automatically updates `release_year` when `release_date` is changed via manual updates.
+- These fixes resolve issues where movies with updated release dates would appear on the wrong date or have mismatched release_year values.
+
 ## v0.1.13 (2025-09-01)
 - Database build date ("Build") is now displayed in the footer of all main pages (About, Index, Search, Details) for improved transparency.
 - The About page Movie Database Statistics section now includes the build date as a list item above the stats.

--- a/app.py
+++ b/app.py
@@ -44,7 +44,7 @@ from fastapi.responses import (
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 
-VERSION = "0.1.13"
+VERSION = "0.1.14"
 
 # At startup, record the start time
 START_TIME = time.time()

--- a/movie_db/build_db.py
+++ b/movie_db/build_db.py
@@ -496,15 +496,18 @@ with open(COMBINED_TMDB_CSV, newline="", encoding="utf-8") as csvfile:
             # Search index for this movie id and update all the data:
             # "id","title","vote_average","vote_count","status","release_date","revenue","runtime","adult","backdrop_path","budget","homepage","imdb_id","original_language","original_title","overview","popularity","poster_path","tagline","genres","production_companies","production_countries","spoken_languages","keywords"
 
-            for movies_list in index.values():
+            for day_key, movies_list in index.items():
                 for mov in movies_list:
                     if mov["id"] == movie_id:
+                        old_release_date = mov.get("release_date")
+                        new_release_date = row["release_date"]
                         mov.update({
                             "popularity": row["popularity"],
                             "vote_average": row["vote_average"],
                             "vote_count": row["vote_count"],
                             "title": row["title"],
-                            "release_date": row["release_date"],
+                            "release_date": new_release_date,
+                            "release_year": new_release_date.split("-")[0] if new_release_date else None,
                             "status": row["status"],
                             "revenue": row["revenue"],
                             "runtime": row["runtime"],
@@ -524,8 +527,15 @@ with open(COMBINED_TMDB_CSV, newline="", encoding="utf-8") as csvfile:
                             "spoken_languages": row["spoken_languages"],
                             "keywords": row["keywords"],
                         })
-                        # status(f"Updated movie {mov['title']} (ID: {movie_id}) with new popularity {mov['popularity']} release date {mov['release_date']}", Fore.MAGENTA)
-                        # print(f"^^ Updated movie {mov['title']} (ID: {movie_id}) with new popularity {mov['popularity']}")
+                        # If release_date changed, move movie to the new MM_DD bucket
+                        if new_release_date and new_release_date != old_release_date:
+                            if len(new_release_date.split("-")) == 3:
+                                new_mm_dd = f"{new_release_date.split('-')[1]}_{new_release_date.split('-')[2]}"
+                                if new_mm_dd != day_key:
+                                    # Remove from current bucket and add to new bucket
+                                    movies_list.remove(mov)
+                                    index[new_mm_dd].append(mov)
+                                    # status(f"Moved movie {mov['title']} from {day_key} to {new_mm_dd}", Fore.MAGENTA)
                         break
             continue
         # Check if the movie meets our criteria
@@ -767,9 +777,12 @@ def apply_updates_jsonl(idx, updates_file_path):
                     for k, v in update_obj.items():
                         if k not in ("imdb_id", "id"):
                             mov[k] = v
-                    # If release_date changed, move movie to new MM_DD index
+                    # If release_date changed, update release_year and move movie to new MM_DD index
                     new_release_date = mov.get("release_date")
                     if new_release_date and new_release_date != old_release_date:
+                        # Update release_year to match new release_date
+                        if len(new_release_date.split("-")) == 3:
+                            mov["release_year"] = new_release_date.split("-")[0]
                         # Remove from old MM_DD
                         if old_release_date and len(old_release_date.split("-")) == 3:
                             old_mmdd = f"{old_release_date.split('-')[1]}_{old_release_date.split('-')[2]}"

--- a/movie_db/updates.jsonl
+++ b/movie_db/updates.jsonl
@@ -1,1 +1,2 @@
 {"imdb_id": "tt0058331", "release_date": "1964-08-27", "release_year": "1964", "movie_title": "Mary Poppins"}
+{"imdb_id": "tt27564844", "omdb_poster": "https://upload.wikimedia.org/wikipedia/en/a/af/Iron_Lung_%28film%29_poster.jpg", "omdb_plot": "In a post-apocalyptic future after \"The Quiet Rapture\" event, a convict explores a blood ocean on a desolate moon using a submarine called the \"Iron Lung\" to search for missing stars and planets", "release_year": "2026", "omdb_rated": "R", "omdb_imdb_rating": "6.7", "omdb_genre": "Horror, Sci-Fi", "movie_title": "Iron Lung"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest
 requests
 colorama
 python-multipart
+python-dotenv

--- a/templates/details.html
+++ b/templates/details.html
@@ -131,7 +131,8 @@
         <div style="margin-top:18px; text-align:center;">
           <div style="font-size:1.05em; color:#22223b; font-weight:600;">IMDb Rating</div>
           <div style="display:flex; align-items:center; justify-content:center; gap:2px; margin-top:4px;">
-            {% set rating = movie.omdb_imdb_rating.split('/')[0] if '/' in movie.omdb_imdb_rating else movie.omdb_imdb_rating %}
+            {% set rating_str = movie.omdb_imdb_rating|string %}
+            {% set rating = rating_str.split('/')[0] if '/' in rating_str else rating_str %}
             {% set rating_val = rating|float %}
             {% for i in range(1, 11) %}
               {% if i <= rating_val|int %}


### PR DESCRIPTION
## v0.1.14 (2026-02-01)
- Fixed: Details page now handles `omdb_imdb_rating` as either float or string, preventing template errors when rating is a numeric type.
- Database build fix: When duplicate movies are found (e.g., movie appears in both main CSV and trending CSV), the movie is now properly moved to the correct MM_DD date bucket if the release date changed.
- Database build fix: `release_year` is now recalculated when a duplicate movie's release date is updated.
- Database build fix: `apply_updates_jsonl` now automatically updates `release_year` when `release_date` is changed via manual updates.
- These fixes resolve issues where movies with updated release dates would appear on the wrong date or have mismatched release_year values.